### PR TITLE
Enhance `ParseOriginPathInfo` to Support Image Retrieval Without Hostname [target: docker.io]

### DIFF
--- a/cmd/crproxy/main.go
+++ b/cmd/crproxy/main.go
@@ -45,6 +45,7 @@ var (
 	redirectLinks        string
 	disableTagsList      bool
 	enablePprof          bool
+	defaultRegistry      string
 )
 
 func init() {
@@ -67,6 +68,7 @@ func init() {
 	pflag.StringVar(&redirectLinks, "redirect-links", "", "redirect links")
 	pflag.BoolVar(&disableTagsList, "disable-tags-list", false, "disable tags list")
 	pflag.BoolVar(&enablePprof, "enable-pprof", false, "Enable pprof")
+	pflag.StringVar(&defaultRegistry, "default-registry", "", "default registry used for non full-path docker pull, like:docker.io")
 	pflag.Parse()
 }
 
@@ -236,6 +238,10 @@ func main() {
 	}
 	if limitDelay {
 		opts = append(opts, crproxy.WithLimitDelay(true))
+	}
+
+	if defaultRegistry != "" {
+		opts = append(opts, crproxy.WithDefaultRegistry(defaultRegistry))
 	}
 
 	crp, err := crproxy.NewCRProxy(opts...)

--- a/crproxy_test.go
+++ b/crproxy_test.go
@@ -6,15 +6,43 @@ import (
 )
 
 func TestParseOriginPathInfo(t *testing.T) {
+
+	var test_defaultRegistry string = "non_docker.io"
+
 	type args struct {
 		path string
 	}
 	tests := []struct {
-		name   string
-		args   args
-		want   *PathInfo
-		wantOk bool
+		name            string
+		args            args
+		defaultRegistry string
+		want            *PathInfo
+		wantOk          bool
 	}{
+		{
+			args: args{
+				path: "/v2/busybox/manifests/1",
+			},
+			defaultRegistry: test_defaultRegistry,
+			want: &PathInfo{
+				Host:      test_defaultRegistry,
+				Image:     "busybox",
+				Manifests: "1",
+			},
+			wantOk: true,
+		},
+		{
+			args: args{
+				path: "/v2/pytorch/pytorch/manifests/1",
+			},
+			defaultRegistry: test_defaultRegistry,
+			want: &PathInfo{
+				Host:      test_defaultRegistry,
+				Image:     "pytorch/pytorch",
+				Manifests: "1",
+			},
+			wantOk: true,
+		},
 		{
 			args: args{
 				path: "/v2/docker.io/busybox/manifests/1",
@@ -40,7 +68,7 @@ func TestParseOriginPathInfo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, gotOk := ParseOriginPathInfo(tt.args.path)
+			got, gotOk := ParseOriginPathInfo(tt.args.path, tt.defaultRegistry)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ParseOriginPathInfo() got = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
# Description

This merge request improves the ParseOriginPathInfo function to allow images to be pulled without specifying a hostname. The hostname used is docker.io.



# Examples
Here are some examples demonstrating the functionality:


```
docker pull 127.0.0.1:8081/busybox
docker pull 127.0.0.1:8081/pytorch/pytorch
docker pull 127.0.0.1:8081/registry.k8s.io/busybox:latest
```

```
[root@sc150 crproxy]# http_proxy=socks5://127.0.0.1:12345 https_proxy=socks5://127.0.0.1:12345  ./crproxy  --behind  -a :
8081                                                         
127.0.0.1 - - [19/Jun/2024:13:29:31 +0800] "GET /v2/ HTTP/1.1" 200 2
127.0.0.1 - - [19/Jun/2024:13:29:31 +0800] "HEAD /v2/busybox/manifests/latest HTTP/1.1" 403 86
127.0.0.1 - - [19/Jun/2024:13:29:31 +0800] "GET /v2/busybox/manifests/latest HTTP/1.1" 403 86


[root@sc150 crproxy]# docker pull 127.0.0.1:8081/busybox
Using default tag: latest
Error response from daemon: denied

^C
[root@sc150 crproxy]# http_proxy=socks5://127.0.0.1:12345 https_proxy=socks5://127.0.0.1:12345  ./crproxy  --behind -a :8081
127.0.0.1 - - [17/Jun/2024:20:56:34 +0800] "GET /v2/ HTTP/1.1" 200 2
[cr proxy] 2024/06/17 20:56:34 cache client registry-1.docker.io library/busybox
[cr proxy] 2024/06/17 20:56:35 ping registry-1.docker.io
127.0.0.1 - - [17/Jun/2024:20:56:34 +0800] "HEAD /v2/busybox/manifests/latest HTTP/1.1" 200 0
127.0.0.1 - - [17/Jun/2024:20:56:45 +0800] "GET /v2/ HTTP/1.1" 200 2
[cr proxy] 2024/06/17 20:56:45 cache client registry.k8s.io busybox
[cr proxy] 2024/06/17 20:56:45 redirect [https://registry.k8s.io/v2/busybox/manifests/latest https://asia-east1-docker.pkg.dev/v2/k8s-artifacts-prod/images/busybox/manifests/latest]
127.0.0.1 - - [17/Jun/2024:20:56:45 +0800] "HEAD /v2/registry.k8s.io/busybox/manifests/latest HTTP/1.1" 200 0
[cr proxy] 2024/06/17 20:56:46 redirect [https://registry.k8s.io/v2/busybox/manifests/sha256:d8d3bc2c183ed2f9f10e7258f84971202325ee6011ba137112e01e30f206de67 https://asia-east1-docker.pkg.dev/v2/k8s-artifacts-prod/images/busybox/manifests/sha256:d8d3bc2c183ed2f9f10e7258f84971202325ee6011ba137112e01e30f206de67]
127.0.0.1 - - [17/Jun/2024:20:56:46 +0800] "GET /v2/registry.k8s.io/busybox/manifests/sha256:d8d3bc2c183ed2f9f10e7258f84971202325ee6011ba137112e01e30f206de67 HTTP/1.1" 200 0



[root@sc150 crproxy]# http_proxy=socks5://127.0.0.1:12345 https_proxy=socks5://127.0.0.1:12345  ./crproxy  --behind --default-registry registry.k8s.io  -a :8081  
127.0.0.1 - - [17/Jun/2024:20:57:28 +0800] "GET /v2/ HTTP/1.1" 200 2
[cr proxy] 2024/06/17 20:57:28 cache client registry.k8s.io busybox
[cr proxy] 2024/06/17 20:57:28 redirect [https://registry.k8s.io/v2/busybox/manifests/latest https://asia-east1-docker.pkg.dev/v2/k8s-artifacts-prod/images/busybox/manifests/latest]
127.0.0.1 - - [17/Jun/2024:20:57:28 +0800] "HEAD /v2/busybox/manifests/latest HTTP/1.1" 200 0
[cr proxy] 2024/06/17 20:57:29 redirect [https://registry.k8s.io/v2/busybox/manifests/sha256:d8d3bc2c183ed2f9f10e7258f84971202325ee6011ba137112e01e30f206de67 https://asia-east1-docker.pkg.dev/v2/k8s-artifacts-prod/images/busybox/manifests/sha256:d8d3bc2c183ed2f9f10e7258f84971202325ee6011ba137112e01e30f206de67]
127.0.0.1 - - [17/Jun/2024:20:57:28 +0800] "GET /v2/busybox/manifests/sha256:d8d3bc2c183ed2f9f10e7258f84971202325ee6011ba137112e01e30f206de67 HTTP/1.1" 200 0
```


Please reach out if you have any questions or need further clarification.

